### PR TITLE
:sparkles: Adding ability to run in current working directory

### DIFF
--- a/wit4java/wit4java.py
+++ b/wit4java/wit4java.py
@@ -63,7 +63,11 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help='Path to the witness file. Must conform to the exchange format'
     )
 
-    parser.add_argument('--local-dir', help='perform all of the processing in the current directory', action='store_true')
+    parser.add_argument(
+        '--local-dir',
+        help='perform all of the processing in the current directory',
+        action='store_true'
+    )
 
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + __version__


### PR DESCRIPTION
# Description

Added the `--local-dir` flag to do all processing and harness creation in the current working directory.

Fixes #20 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on sv-comp benchmarks locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules